### PR TITLE
Use `a` to access `world` in collisions only after is null check in all 4 collision callbacks

### DIFF
--- a/windfield/init.lua
+++ b/windfield/init.lua
@@ -354,11 +354,10 @@ end
 
 function World.collisionOnEnter(fixture_a, fixture_b, contact)
     local a, b = fixture_a:getUserData(), fixture_b:getUserData()
-    local world = a.world
 
     if fixture_a:isSensor() and fixture_b:isSensor() then
         if a and b then
-            for _, collision in ipairs(world.collisions.on_enter.sensor) do
+            for _, collision in ipairs(a.world.collisions.on_enter.sensor) do
                 if collIf(collision.type1, collision.type2, a, b) then
                     a, b = collEnsure(collision.type1, a, collision.type2, b)
                     table.insert(a.collision_events[collision.type2], {collision_type = 'enter', collider_1 = a, collider_2 = b, contact = contact})
@@ -371,7 +370,7 @@ function World.collisionOnEnter(fixture_a, fixture_b, contact)
 
     elseif not (fixture_a:isSensor() or fixture_b:isSensor()) then
         if a and b then
-            for _, collision in ipairs(world.collisions.on_enter.non_sensor) do
+            for _, collision in ipairs(a.world.collisions.on_enter.non_sensor) do
                 if collIf(collision.type1, collision.type2, a, b) then
                     a, b = collEnsure(collision.type1, a, collision.type2, b)
                     table.insert(a.collision_events[collision.type2], {collision_type = 'enter', collider_1 = a, collider_2 = b, contact = contact})
@@ -386,11 +385,10 @@ end
 
 function World.collisionOnExit(fixture_a, fixture_b, contact)
     local a, b = fixture_a:getUserData(), fixture_b:getUserData()
-    local world = a.world
 
     if fixture_a:isSensor() and fixture_b:isSensor() then
         if a and b then
-            for _, collision in ipairs(world.collisions.on_exit.sensor) do
+            for _, collision in ipairs(a.world.collisions.on_exit.sensor) do
                 if collIf(collision.type1, collision.type2, a, b) then
                     a, b = collEnsure(collision.type1, a, collision.type2, b)
                     table.insert(a.collision_events[collision.type2], {collision_type = 'exit', collider_1 = a, collider_2 = b, contact = contact})
@@ -403,7 +401,7 @@ function World.collisionOnExit(fixture_a, fixture_b, contact)
 
     elseif not (fixture_a:isSensor() or fixture_b:isSensor()) then
         if a and b then
-            for _, collision in ipairs(world.collisions.on_exit.non_sensor) do
+            for _, collision in ipairs(a.world.collisions.on_exit.non_sensor) do
                 if collIf(collision.type1, collision.type2, a, b) then
                     a, b = collEnsure(collision.type1, a, collision.type2, b)
                     table.insert(a.collision_events[collision.type2], {collision_type = 'exit', collider_1 = a, collider_2 = b, contact = contact})
@@ -418,11 +416,10 @@ end
 
 function World.collisionPre(fixture_a, fixture_b, contact)
     local a, b = fixture_a:getUserData(), fixture_b:getUserData()
-    local world = a.world
 
     if fixture_a:isSensor() and fixture_b:isSensor() then
         if a and b then
-            for _, collision in ipairs(world.collisions.pre.sensor) do
+            for _, collision in ipairs(a.world.collisions.pre.sensor) do
                 if collIf(collision.type1, collision.type2, a, b) then
                     a, b = collEnsure(collision.type1, a, collision.type2, b)
                     a:preSolve(b, contact)
@@ -435,7 +432,7 @@ function World.collisionPre(fixture_a, fixture_b, contact)
 
     elseif not (fixture_a:isSensor() or fixture_b:isSensor()) then
         if a and b then
-            for _, collision in ipairs(world.collisions.pre.non_sensor) do
+            for _, collision in ipairs(a.world.collisions.pre.non_sensor) do
                 if collIf(collision.type1, collision.type2, a, b) then
                     a, b = collEnsure(collision.type1, a, collision.type2, b)
                     a:preSolve(b, contact)
@@ -450,11 +447,10 @@ end
 
 function World.collisionPost(fixture_a, fixture_b, contact, ni1, ti1, ni2, ti2)
     local a, b = fixture_a:getUserData(), fixture_b:getUserData()
-    local world = a.world
 
     if fixture_a:isSensor() and fixture_b:isSensor() then
         if a and b then
-            for _, collision in ipairs(world.collisions.post.sensor) do
+            for _, collision in ipairs(a.world.collisions.post.sensor) do
                 if collIf(collision.type1, collision.type2, a, b) then
                     a, b = collEnsure(collision.type1, a, collision.type2, b)
                     a:postSolve(b, contact, ni1, ti1, ni2, ti2)
@@ -467,7 +463,7 @@ function World.collisionPost(fixture_a, fixture_b, contact, ni1, ti1, ni2, ti2)
 
     elseif not (fixture_a:isSensor() or fixture_b:isSensor()) then
         if a and b then
-            for _, collision in ipairs(world.collisions.post.non_sensor) do
+            for _, collision in ipairs(a.world.collisions.post.non_sensor) do
                 if collIf(collision.type1, collision.type2, a, b) then
                     a, b = collEnsure(collision.type1, a, collision.type2, b)
                     a:postSolve(b, contact, ni1, ti1, ni2, ti2)
@@ -906,3 +902,4 @@ wf.World = World
 wf.Collider = Collider
 
 return wf
+


### PR DESCRIPTION
This commit calls a.world only after it is not null, as I was running into errors when deleting various bodies when the callback still tried to access the `world` of a nil variable. I then saw the `if a and b` check a few lines down and as far as I can tell moving the world access after this check removed the error.