### PR TITLE
fix world:NewChainCollider(vertices, loop)

### DIFF
--- a/windfield/init.lua
+++ b/windfield/init.lua
@@ -738,7 +738,7 @@ function Collider.new(world, collider_type, ...)
     elseif self.type == 'Chain' then
         self.collision_class = (args[3] and args[3].collision_class) or 'Default'
         self.body = love.physics.newBody(self.world.box2d_world, 0, 0, (args[3] and args[3].body_type) or 'dynamic')
-        shape = love.physics.newChainShape(args[1], unpack(args[2]))
+        shape = love.physics.newChainShape(args[2], unpack(args[1]))
     end
 
     -- Define collision classes and attach them to fixture and sensor


### PR DESCRIPTION
Hello,

Found this bug using love 11.1:

```
Error: lib/windfield/init.lua:741: bad argument #1 to 'unpack' (table expected, got boolean)
stack traceback:
        [string "boot.lua"]:637: in function <[string "boot.lua"]:633>
        [C]: in function 'unpack'
        lib/windfield/init.lua:741: in function 'newChainCollider'
```